### PR TITLE
fold-artwork.sh: fix typo quite->quiet in variable

### DIFF
--- a/fold-artwork.sh
+++ b/fold-artwork.sh
@@ -162,7 +162,7 @@ fold_it() {
     fold_it_2
     return $?
   fi
-  quiet_sav=$quite
+  quiet_sav=$quiet
   quiet=1
   fold_it_1
   result=$?


### PR DESCRIPTION
Hi,

this pull request is intended to fix a typo in a variable name. The contents of the variable `quite` are saved in variable `quiet_sav`, and later restored to variable `quiet`. There is no variable `quite`, but there is variable called `quiet` that seems to be intended to be saved by the changed code.

Thanks,
Erik