### PR TITLE
fold-artwork.sh: make first line Linux compatible

### DIFF
--- a/fold-artwork.sh
+++ b/fold-artwork.sh
@@ -1,4 +1,5 @@
-#!/bin/bash --posix   # must be `bash` (not `sh`)
+#!/bin/bash --posix
+# must be `bash` (not `sh`)
 
 print_usage() {
   echo


### PR DESCRIPTION
Hi,

this pull request is intended to allow the script to be used on systems with the Linux kernel.

The Linux kernel follows the POSIX standard in separating the first
line of a script into two parts:

1. The interpreter binary to invoke.
2. The single option provided to the interpreter (this may be
   truncated).

Thus on Linux, the command line is thus:

    'bash' '--posix   # must be `bash` (not `sh`)' 'fold-artwork.sh'
     ^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^
     $0     $1                                      $2

Bash doesn't recognize the option '--posix   # must be `bash` (not `sh`)',
thus the script does not work on Linux or POSIX conforming kernels.

The fix is to move the comment into the second line of the script,
which is not interpreted by the kernel, but only by the invoked
interpreter, i.e. Bash.

Please note that the script still does not work on GNU/Linux systems,
because those do not know the name 'gsed' for GNU sed, it is just
called 'sed'. Replacing every instance of 'gsed' with 'sed' and
if necessary installing 'pcregrep' allows the script to be used on
GNU/Linux systems.

Thanks,
Erik