### PR TITLE
fold-artwork.sh: add terse info about portability

### DIFF
--- a/fold-artwork.sh
+++ b/fold-artwork.sh
@@ -1,6 +1,10 @@
 #!/bin/bash --posix
 # must be `bash` (not `sh`)
 
+# This script may need some adjustments to work on a given system:
+# * the utility `pcregrep` may need to be installed
+# * the utility `gsed` is called `sed` on e.g. GNU systems
+
 print_usage() {
   echo
   echo "Folds the text file, only if needed, at the specified"


### PR DESCRIPTION
Add just the information of what needs to be considered, but
omit specific ways of implementing this (search & replace varies
between editors, package manager names and commands differ as well).

On non-GNU systems, GNU utilities are often installed with
a prefix of 'g' added to the name (e.g. `gsed` instead of
`sed`), but GNU systems usually omit this prefix. Examples
for GNU systems are GNU/Linux distributions, examples for
non-GNU systems are e.g. the various BSD unices, proprietary
Unix operating systems like AIX or Solaris, and macOS.

The `pcregrep` utility is not part of POSIX, and it is missing
from many default installations of Unix-like systems, thus
it usually needs to be installed. This installation can be a
traditional `make install`, or invoking some kind of package
manager, or whatever is appropriate for the given system.