### PR TITLE
fold-artwork.sh: fix strategy 2 unfolding

### DIFF
--- a/fold-artwork.sh
+++ b/fold-artwork.sh
@@ -190,8 +190,7 @@ unfold_it_2() {
   awk "NR>2" $infile > $temp_dir/wip
 
   # unfold wip file
-  gsed ":x; /.*\\\\$/N; s/\\\\\n[ ]*\\\\//; tx" $temp_dir/wip \
-    > $outfile
+  gsed ':START;$!N;s/\\\n *\\//;tSTART;P;D' $temp_dir/wip > $outfile
 
   # clean up and return
   rm -rf $temp_dir


### PR DESCRIPTION
Hi Kent,

the failing test `why-wont-2-unfold-this.txt` in `validate-all.sh` happened because unfolding did not work in that test case, folding worked as expected. Changing the `gsed` invocation as in this pull request fixes this.

After this commit, all tests (`refs/validate-all.sh`) pass.

Thanks,
Erik