### PR TITLE
Changes to sed and cleanup of temporary files

### DIFF
--- a/rfcfold
+++ b/rfcfold
@@ -181,7 +181,7 @@ unfold_it_1() {
   awk "NR>2" $infile > $temp_dir/wip
 
   # unfold wip file
-  "$SED" ":x; /.*\\\\$/N; s/\\\\\n[ ]*//; tx" $temp_dir/wip > $outfile
+  "$SED" ':START;$!N;s/\\\n *//;tSTART;P;D' $temp_dir/wip > $outfile
 
   # clean up and return
   rm -rf $temp_dir

--- a/rfcfold
+++ b/rfcfold
@@ -2,8 +2,7 @@
 # must use `bash` (not `sh`)
 
 # This script may need some adjustments to work on a given system.
-# For instance, the utility `pcregrep` may need to be installed,
-# and GNU sed needs to be available under the name `gsed` or `sed`.
+# For instance, the utility `pcregrep` may need to be installed.
 
 print_usage() {
   echo
@@ -84,7 +83,7 @@ fold_it_1() {
   # generate outfile
   echo "$header" > $outfile
   echo "" >> $outfile
-  "$SED" -r 's/(.{68})(..)/\1\\\n\2/;tMORE;bEND;:MORE;P;D;:END'\
+  "$SED" 's/\(.\{68\}\)\(..\)/\1\\\n\2/;tMORE;bEND;:MORE;P;D;:END'\
     < $infile >> $outfile
 
   return 0
@@ -122,7 +121,7 @@ fold_it_2() {
   # generate outfile
   echo "$header" > $outfile
   echo "" >> $outfile
-  "$SED" -r 's/(.{68})(..)/\1\\\n\\\2/;tMORE;bEND;:MORE;P;D;:END'\
+  "$SED" 's/\(.\{68\}\)\(..\)/\1\\\n\\\2/;tMORE;bEND;:MORE;P;D;:END'\
     < $infile >> $outfile
 
   return 0

--- a/rfcfold
+++ b/rfcfold
@@ -42,6 +42,11 @@ temp_dir=""
 # determine name of [g]sed binary
 type gsed > /dev/null 2>&1 && SED=gsed || SED=sed
 
+cleanup() {
+  rm -rf "$temp_dir"
+}
+trap 'cleanup' EXIT
+
 fold_it_1() {
   # ensure input file doesn't contain the fold-sequence already
   pcregrep -M  "\\\\\n" $infile >> /dev/null 2>&1
@@ -183,8 +188,6 @@ unfold_it_1() {
   # unfold wip file
   "$SED" ':START;$!N;s/\\\n *//;tSTART;P;D' $temp_dir/wip > $outfile
 
-  # clean up and return
-  rm -rf $temp_dir
   return 0
 }
 
@@ -197,8 +200,6 @@ unfold_it_2() {
   # unfold wip file
   "$SED" ':START;$!N;s/\\\n *\\//;tSTART;P;D' $temp_dir/wip > $outfile
 
-  # clean up and return
-  rm -rf $temp_dir
   return 0
 }
 

--- a/rfcfold
+++ b/rfcfold
@@ -3,7 +3,7 @@
 
 # This script may need some adjustments to work on a given system.
 # For instance, the utility `pcregrep` may need to be installed,
-# and the utility `gsed` is called `sed` on e.g., GNU systems
+# and GNU sed needs to be available under the name `gsed` or `sed`.
 
 print_usage() {
   echo
@@ -39,6 +39,9 @@ hdr_txt_2="NOTE: '\\\\' line wrapping per BCP XX (RFC XXXX)"
 equal_chars="=============================================="
 space_chars="                                              "
 temp_dir=""
+
+# determine name of [g]sed binary
+type gsed > /dev/null 2>&1 && SED=gsed || SED=sed
 
 fold_it_1() {
   # ensure input file doesn't contain the fold-sequence already
@@ -81,7 +84,7 @@ fold_it_1() {
   # generate outfile
   echo "$header" > $outfile
   echo "" >> $outfile
-  gsed -r 's/(.{68})(..)/\1\\\n\2/;tMORE;bEND;:MORE;P;D;:END'\
+  "$SED" -r 's/(.{68})(..)/\1\\\n\2/;tMORE;bEND;:MORE;P;D;:END'\
     < $infile >> $outfile
 
   return 0
@@ -119,7 +122,7 @@ fold_it_2() {
   # generate outfile
   echo "$header" > $outfile
   echo "" >> $outfile
-  gsed -r 's/(.{68})(..)/\1\\\n\\\2/;tMORE;bEND;:MORE;P;D;:END'\
+  "$SED" -r 's/(.{68})(..)/\1\\\n\\\2/;tMORE;bEND;:MORE;P;D;:END'\
     < $infile >> $outfile
 
   return 0
@@ -179,7 +182,7 @@ unfold_it_1() {
   awk "NR>2" $infile > $temp_dir/wip
 
   # unfold wip file
-  gsed ":x; /.*\\\\$/N; s/\\\\\n[ ]*//; tx" $temp_dir/wip > $outfile
+  "$SED" ":x; /.*\\\\$/N; s/\\\\\n[ ]*//; tx" $temp_dir/wip > $outfile
 
   # clean up and return
   rm -rf $temp_dir
@@ -193,7 +196,7 @@ unfold_it_2() {
   awk "NR>2" $infile > $temp_dir/wip
 
   # unfold wip file
-  gsed ':START;$!N;s/\\\n *\\//;tSTART;P;D' $temp_dir/wip > $outfile
+  "$SED" ':START;$!N;s/\\\n *\\//;tSTART;P;D' $temp_dir/wip > $outfile
 
   # clean up and return
   rm -rf $temp_dir


### PR DESCRIPTION
Hi Kent,

this pull request contains several changes:

1. Try to use `gsed` and fall back to `sed` if no `gsed` is found.
2. Remove the non-POSIX option `-r` from `sed` invocations (it was introduced by me).
3. Use the same style sed script for unfolding in both strategies.
4. Ensure that temporary files are deleted (`validate-all.sh` left a lot of temporary files behind)

One pull request for simplicity, especially since changes 1 to 3 are interdependent.

Thanks,
Erik