### PR TITLE
No recursive unfolding

### DIFF
--- a/refs/neither-can-fold-it-1.force-folded.1.txt
+++ b/refs/neither-can-fold-it-1.force-folded.1.txt
@@ -6,5 +6,6 @@
 
 # the following fails preconditions set for both strategies
 12345678\
-9\
+9\\
+
 \2345

--- a/refs/neither-can-fold-it-1.force-folded.2.txt
+++ b/refs/neither-can-fold-it-1.force-folded.2.txt
@@ -6,5 +6,6 @@
 
 # the following fails preconditions set for both strategies
 12345678\
-\9\
+\9\\
+\
 \2345

--- a/refs/neither-can-fold-it-2.force-folded.1.txt
+++ b/refs/neither-can-fold-it-2.force-folded.1.txt
@@ -6,5 +6,6 @@
 
 # the following fails preconditions set for both strategies
 12345678\
-9\
+9\\
+
    \567

--- a/refs/neither-can-fold-it-2.force-folded.2.txt
+++ b/refs/neither-can-fold-it-2.force-folded.2.txt
@@ -6,5 +6,6 @@
 
 # the following fails preconditions set for both strategies
 12345678\
-\9\
+\9\\
+\
    \567

--- a/refs/validate-all.sh
+++ b/refs/validate-all.sh
@@ -77,9 +77,9 @@ main() {
   test_file 2 neither-can-fold-it-2.txt 1
   echo
   echo "starting unfolding forced tests..."
-  #test_prefolded_file 1 neither-can-fold-it-1.force-folded.1.txt neither-can-fold-it-1.txt
+  test_prefolded_file 1 neither-can-fold-it-1.force-folded.1.txt neither-can-fold-it-1.txt
   test_prefolded_file 2 neither-can-fold-it-1.force-folded.2.txt neither-can-fold-it-1.txt
-  #test_prefolded_file 1 neither-can-fold-it-2.force-folded.1.txt neither-can-fold-it-2.txt
+  test_prefolded_file 1 neither-can-fold-it-2.force-folded.1.txt neither-can-fold-it-2.txt
   test_prefolded_file 2 neither-can-fold-it-2.force-folded.2.txt neither-can-fold-it-2.txt
 
   echo

--- a/refs/validate-all.sh
+++ b/refs/validate-all.sh
@@ -113,12 +113,16 @@ main() {
   test_file 2 nofold-needed.txt        1   x  67
   test_file 2 nofold-needed-again.txt  0   0  67
   echo
-
-
-
-command="diff -q example-3.1.txt.folded.smart.unfolded example-3.2.txt.folded.smart.unfolded"
-expected_exit_code=0
-run_cmd "$command" $expected_exit_code
+  printf "testing unfolding of smart folding examples 3.1 and 3.2..."
+  expected_exit_code=0
+  command="../rfcfold -r -i example-3.1.txt.folded.smart -o example-3.1.txt.folded.smart.unfolded"
+  run_cmd "$command" $expected_exit_code
+  command="../rfcfold -r -i example-3.2.txt.folded.smart -o example-3.2.txt.folded.smart.unfolded"
+  run_cmd "$command" $expected_exit_code
+  command="diff -q example-3.1.txt.folded.smart.unfolded example-3.2.txt.folded.smart.unfolded"
+  run_cmd "$command" $expected_exit_code
+  rm example-3.1.txt.folded.smart.unfolded example-3.2.txt.folded.smart.unfolded
+  echo "okay."
 
 }
 

--- a/rfcfold
+++ b/rfcfold
@@ -233,7 +233,7 @@ unfold_it_1() {
   awk "NR>2" $infile > $temp_dir/wip
 
   # unfold wip file
-  "$SED" ':S;$!N;s/\\\n *//;t S;P;D' $temp_dir/wip > $outfile
+  "$SED" '{H;$!d};x;s/^\n//;s/\\\n *//g' $temp_dir/wip > $outfile
 
   return 0
 }
@@ -245,7 +245,7 @@ unfold_it_2() {
   awk "NR>2" $infile > $temp_dir/wip
 
   # unfold wip file
-  "$SED" ':S;$!N;s/\\\n *\\//;t S;P;D' $temp_dir/wip > $outfile
+  "$SED" '{H;$!d};x;s/^\n//;s/\\\n *\\//g' $temp_dir/wip > $outfile
 
   return 0
 }


### PR DESCRIPTION
# No Recursive Unfolding

This pull request addresses the issue of not being able to fold and then unfold files that contain the folding pattern in the original data already (`<backslash><end of line sequence><optional space characters>` for strategy one, `<backslash><end of line sequence><optional space characters><backslash>` for strategy two). Recursive unfolding would unfold the original data as well, although unfolding should have left it alone.

I would recommend to clearly state somewhere in the text of the Internet Draft that a recursive unfolding strategy, as used by `rfcfold` before this pull request, does not conform to the line folding method described in the Internet Draft. Adding force-folding examples might suffice.

#### Example for strategy one:

Original data:
```
123456789\
12345
```
Force-folded data:
```
123456789\\

12345
```
#### Example for strategy two:

Original data:
```
123456789\
   \567
```
Force-folded data:
```
123456789\\
\
    \567
```