### PR TITLE
Better align with "common shell style"

### DIFF
--- a/refs/validate-all.sh
+++ b/refs/validate-all.sh
@@ -4,7 +4,7 @@ run_cmd() {
   # $1 is the cmd to run
   # $2 is the expected error code
 
-  output=`$1`
+  output=`$1 2>&1`
   exit_code=$?
   if [[ $exit_code -ne $2 ]]; then
     printf "failed.\n"
@@ -25,9 +25,9 @@ test_file() {
   printf "testing $2..."
 
   if [ -z "$5" ]; then
-    command="../rfcfold -s $1 -d -i $2 -o $2.folded 2>&1"
+    command="../rfcfold -s $1 -d -i $2 -o $2.folded"
   else
-    command="../rfcfold -s $1 -d -c $5 -i $2 -o $2.folded 2>&1"
+    command="../rfcfold -s $1 -d -c $5 -i $2 -o $2.folded"
   fi
   expected_exit_code=$3
   run_cmd "$command" $expected_exit_code
@@ -39,7 +39,7 @@ test_file() {
     return
   fi
 
-  command="../rfcfold -d -r -i $2.folded -o $2.folded.unfolded 2>&1"
+  command="../rfcfold -d -r -i $2.folded -o $2.folded.unfolded"
   expected_exit_code=$4
   run_cmd "$command" $expected_exit_code
 
@@ -58,7 +58,7 @@ test_unfoldable_file() {
 
   printf "testing $2..."
 
-  command="../rfcfold -d -r -i $2 -o $2.unfolded 2>&1"
+  command="../rfcfold -d -r -i $2 -o $2.unfolded"
   expected_exit_code=$3
   run_cmd "$command" $expected_exit_code
 
@@ -75,7 +75,7 @@ test_prefolded_file() {
 
   printf "testing $2..."
 
-  command="../rfcfold -d -r -i $2 -o $2.unfolded 2>&1"
+  command="../rfcfold -d -r -i $2 -o $2.unfolded"
   expected_exit_code=0
   run_cmd "$command" $expected_exit_code
 

--- a/refs/validate-all.sh
+++ b/refs/validate-all.sh
@@ -130,7 +130,7 @@ main() {
   test_file 1 only-2-can-fold-it-5.txt 1
   test_file 2 only-2-can-fold-it-5.txt 0   0
   test_file 1 only-2-can-fold-it-6.txt 1
-  test_file 2 only-2-can-fold-it-6.txt 0  0
+  test_file 2 only-2-can-fold-it-6.txt 0   0
   echo
   echo "starting strategy #1 tests..."
   test_file 1 contains-tab.txt         1

--- a/refs/validate-all.sh
+++ b/refs/validate-all.sh
@@ -158,7 +158,8 @@ main() {
   run_cmd "$command" $expected_exit_code
   rm example-3.1.txt.folded.smart.unfolded example-3.2.txt.folded.smart.unfolded
   echo "okay."
-
+  echo
+  echo "all tests passed."
 }
 
 main "$@"

--- a/rfcfold
+++ b/rfcfold
@@ -289,7 +289,7 @@ unfold_it() {
 
 process_input() {
   while [[ "$1" != "" ]]; do
-    if [ "$1" == "-h" -o "$1" == "--help" ]; then
+    if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
       print_usage
       exit 0
     fi

--- a/rfcfold
+++ b/rfcfold
@@ -248,7 +248,8 @@ unfold_it_2() {
   awk "NR>2" "$infile" > "$temp_dir/wip"
 
   # unfold wip file
-  "$SED" '{H;$!d};x;s/^\n//;s/\\\n *\\//g' "$temp_dir/wip" > "$outfile"
+  "$SED" '{H;$!d};x;s/^\n//;s/\\\n *\\//g' "$temp_dir/wip"\
+    > "$outfile"
 
   return 0
 }

--- a/rfcfold
+++ b/rfcfold
@@ -303,31 +303,28 @@ process_input() {
     if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
       print_usage
       exit 0
-    fi
-    if [[ "$1" == "-d" ]]; then
+    elif [[ "$1" == "-d" ]]; then
       debug=1
-    fi
-    if [[ "$1" == "-q" ]]; then
+    elif [[ "$1" == "-q" ]]; then
       quiet=1
-    fi
-    if [[ "$1" == "-s" ]]; then
+    elif [[ "$1" == "-s" ]]; then
       strategy="$2"
       shift
-    fi
-    if [[ "$1" == "-c" ]]; then
+    elif [[ "$1" == "-c" ]]; then
       maxcol="$2"
       shift
-    fi
-    if [[ "$1" == "-r" ]]; then
+    elif [[ "$1" == "-r" ]]; then
       reversed=1
-    fi
-    if [[ "$1" == "-i" ]]; then
+    elif [[ "$1" == "-i" ]]; then
       infile="$2"
       shift
-    fi
-    if [[ "$1" == "-o" ]]; then
+    elif [[ "$1" == "-o" ]]; then
       outfile="$2"
       shift
+    else
+      if [[ "$quiet" -eq 0 ]]; then
+        warn "ignoring unknown option '$1'"
+      fi
     fi
     shift 
   done

--- a/rfcfold
+++ b/rfcfold
@@ -373,7 +373,7 @@ process_input() {
 }
 
 main() {
-  if [ "$#" == "0" ]; then
+  if [ "$#" -eq "0" ]; then
      print_usage
      exit 1
   fi

--- a/rfcfold
+++ b/rfcfold
@@ -97,7 +97,7 @@ fold_it_1() {
   # ensure input file doesn't contain the fold-sequence already
   pcregrep -q -M  "\\\\\n" "$infile"
   if [[ $? -eq 0 ]]; then
-    if [[ $quiet -eq 0 ]]; then
+    if [[ "$quiet" -eq 0 ]]; then
       echo
       echo "Error: infile has a line ending with a '\\' character."
       echo "This file cannot be folded using the '\\' strategy"
@@ -115,7 +115,7 @@ fold_it_1() {
   # ensure input file doesn't contain whitespace on the fold column
   grep -q "^.\{$foldcol\} " "$infile"
   if [[ $? -eq 0 ]]; then
-    if [[ $quiet -eq 0 ]]; then
+    if [[ "$quiet" -eq 0 ]]; then
       echo
       echo "Error: infile has a space character occurring on the"
       echo "folding column. This file cannot be folded using the"
@@ -150,7 +150,7 @@ fold_it_2() {
   # ensure input file doesn't contain the fold-sequence already
   pcregrep -q -M  "\\\\\n[\ ]*\\\\" "$infile"
   if [[ $? -eq 0 ]]; then
-    if [[ $quiet -eq 0 ]]; then
+    if [[ "$quiet" -eq 0 ]]; then
       echo
       echo "Error: infile has a line ending with a '\\' character"
       echo "followed by a '\\' character as the first non-space"
@@ -186,7 +186,7 @@ fold_it() {
   # ensure input file doesn't contain a TAB
   grep -q $'\t' "$infile"
   if [[ $? -eq 0 ]]; then
-    if [[ $quiet -eq 0 ]]; then
+    if [[ "$quiet" -eq 0 ]]; then
       echo
       echo "Error: infile contains a TAB character, which is"
       echo "not allowed."
@@ -199,28 +199,28 @@ fold_it() {
   testcol=$(expr "$maxcol" + 1)
   grep -q ".\{$testcol\}" "$infile"
   if [ $? -ne 0 ]; then
-    if [[ $debug -eq 1 ]]; then
+    if [[ "$debug" -eq 1 ]]; then
       echo "nothing to do"
     fi
     cp "$infile" "$outfile"
     return -1
   fi
 
-  if [[ $strategy -eq 1 ]]; then
+  if [[ "$strategy" -eq 1 ]]; then
     fold_it_1
     return $?
   fi
-  if [[ $strategy -eq 2 ]]; then
+  if [[ "$strategy" -eq 2 ]]; then
     fold_it_2
     return $?
   fi
-  quiet_sav=$quiet
+  quiet_sav="$quiet"
   quiet=1
   fold_it_1
   result=$?
-  quiet=$quiet_sav
-  if [[ $result -ne 0 ]]; then
-    if [[ $debug -eq 1 ]]; then
+  quiet="$quiet_sav"
+  if [[ "$result" -ne 0 ]]; then
+    if [[ "$debug" -eq 1 ]]; then
       echo "Folding strategy 1 didn't succeed, trying strategy 2..."
     fi
     fold_it_2
@@ -256,11 +256,11 @@ unfold_it_2() {
 unfold_it() {
   # check if file needs unfolding
   line=$(head -n 1 "$infile")
-  line2=$($SED -n '2p' "$infile")
+  line2=$("$SED" -n '2p' "$infile")
   result=$(echo "$line" | fgrep "$hdr_txt_1")
   if [ $? -eq 0 ]; then
     if [ -n "$line2" ]; then
-      if [[ $quiet -eq 0 ]]; then
+      if [[ "$quiet" -eq 0 ]]; then
         echo "Error: the second line is not empty."
       fi
       return 1
@@ -268,10 +268,10 @@ unfold_it() {
     unfold_it_1
     return $?
   fi
-  result=$(echo $line | fgrep "$hdr_txt_2")
+  result=$(echo "$line" | fgrep "$hdr_txt_2")
   if [ $? -eq 0 ]; then
     if [ -n "$line2" ]; then
-      if [[ $quiet -eq 0 ]]; then
+      if [[ "$quiet" -eq 0 ]]; then
         echo "Error: the second line is not empty."
       fi
       return 1
@@ -279,7 +279,7 @@ unfold_it() {
     unfold_it_2
     return $?
   fi
-  if [[ $debug -eq 1 ]]; then
+  if [[ "$debug" -eq 1 ]]; then
     echo "nothing to do"
   fi
   cp "$infile" "$outfile"
@@ -321,7 +321,7 @@ process_input() {
   done
 
   if [[ -z "$infile" ]]; then
-    if [[ $quiet -eq 0 ]]; then
+    if [[ "$quiet" -eq 0 ]]; then
       echo
       echo "Error: infile parameter missing (use -h for help)"
       echo
@@ -330,7 +330,7 @@ process_input() {
   fi
 
   if [[ -z "$outfile" ]]; then
-    if [[ $quiet -eq 0 ]]; then
+    if [[ "$quiet" -eq 0 ]]; then
       echo
       echo "Error: outfile parameter missing (use -h for help)"
       echo
@@ -339,7 +339,7 @@ process_input() {
   fi
 
   if [[ ! -f "$infile" ]]; then
-    if [[ $quiet -eq 0 ]]; then
+    if [[ "$quiet" -eq 0 ]]; then
       echo
       echo "Error: specified file \"$infile\" is does not exist."
       echo
@@ -347,13 +347,13 @@ process_input() {
     fi
   fi
 
-  if [[ $strategy -eq 2 ]]; then
+  if [[ "$strategy" -eq 2 ]]; then
     min_supported=$(expr ${#hdr_txt_2} + 9)
   else
     min_supported=$(expr ${#hdr_txt_1} + 9)
   fi
-  if [[ $maxcol -lt $min_supported ]]; then
-    if [[ $quiet -eq 0 ]]; then
+  if [[ "$maxcol" -lt "$min_supported" ]]; then
+    if [[ "$quiet" -eq 0 ]]; then
       printf "\nError: the folding column cannot be less than"
       printf " $min_supported.\n\n"
     fi
@@ -363,8 +363,8 @@ process_input() {
   # this is only because the code otherwise runs out of equal_chars
   max_supported=$(expr ${#equal_chars} + 1 + ${#hdr_txt_1} + 1\
        + ${#equal_chars})
-  if [[ $maxcol -gt $max_supported ]]; then
-    if [[ $quiet -eq 0 ]]; then
+  if [[ "$maxcol" -gt "$max_supported" ]]; then
+    if [[ "$quiet" -eq 0 ]]; then
       printf "\nError: the folding column cannot be more than"
       printf " $max_supported.\n\n"
     fi
@@ -380,14 +380,14 @@ main() {
 
   process_input "$@"
 
-  if [[ $reversed -eq 0 ]]; then
+  if [[ "$reversed" -eq 0 ]]; then
     fold_it
     code=$?
   else
     unfold_it
     code=$?
   fi
-  exit $code
+  exit "$code"
 }
 
 main "$@"

--- a/rfcfold
+++ b/rfcfold
@@ -198,7 +198,7 @@ fold_it() {
   # check if file needs folding
   testcol=$(expr "$maxcol" + 1)
   grep -q ".\{$testcol\}" "$infile"
-  if [ $? -ne 0 ]; then
+  if [[ $? -ne 0 ]]; then
     if [[ "$debug" -eq 1 ]]; then
       echo "nothing to do"
     fi
@@ -258,8 +258,8 @@ unfold_it() {
   line=$(head -n 1 "$infile")
   line2=$("$SED" -n '2p' "$infile")
   result=$(echo "$line" | fgrep "$hdr_txt_1")
-  if [ $? -eq 0 ]; then
-    if [ -n "$line2" ]; then
+  if [[ $? -eq 0 ]]; then
+    if [[ -n "$line2" ]]; then
       if [[ "$quiet" -eq 0 ]]; then
         echo "Error: the second line is not empty."
       fi
@@ -269,8 +269,8 @@ unfold_it() {
     return $?
   fi
   result=$(echo "$line" | fgrep "$hdr_txt_2")
-  if [ $? -eq 0 ]; then
-    if [ -n "$line2" ]; then
+  if [[ $? -eq 0 ]]; then
+    if [[ -n "$line2" ]]; then
       if [[ "$quiet" -eq 0 ]]; then
         echo "Error: the second line is not empty."
       fi
@@ -287,33 +287,33 @@ unfold_it() {
 }
 
 process_input() {
-  while [ "$1" != "" ]; do
+  while [[ "$1" != "" ]]; do
     if [ "$1" == "-h" -o "$1" == "--help" ]; then
       print_usage
       exit 0
     fi
-    if [ "$1" == "-d" ]; then
+    if [[ "$1" == "-d" ]]; then
       debug=1
     fi
-    if [ "$1" == "-q" ]; then
+    if [[ "$1" == "-q" ]]; then
       quiet=1
     fi
-    if [ "$1" == "-s" ]; then
+    if [[ "$1" == "-s" ]]; then
       strategy="$2"
       shift
     fi
-    if [ "$1" == "-c" ]; then
+    if [[ "$1" == "-c" ]]; then
       maxcol="$2"
       shift
     fi
-    if [ "$1" == "-r" ]; then
+    if [[ "$1" == "-r" ]]; then
       reversed=1
     fi
-    if [ "$1" == "-i" ]; then
+    if [[ "$1" == "-i" ]]; then
       infile="$2"
       shift
     fi
-    if [ "$1" == "-o" ]; then
+    if [[ "$1" == "-o" ]]; then
       outfile="$2"
       shift
     fi
@@ -373,7 +373,7 @@ process_input() {
 }
 
 main() {
-  if [ "$#" -eq "0" ]; then
+  if [[ "$#" -eq "0" ]]; then
      print_usage
      exit 1
   fi

--- a/rfcfold
+++ b/rfcfold
@@ -73,6 +73,26 @@ hdr_txt_2="NOTE: '\\\\' line wrapping per BCP XXX (RFC XXXX)"
 equal_chars="======================================================="
 space_chars="                                                       "
 temp_dir=""
+prog_name='rfcfold'
+
+# functions for diagnostic messages
+prog_msg() {
+  format_string="${prog_name}: $1: %s\n"
+  shift
+  printf -- "$format_string" "$@" >&2
+}
+
+err() {
+  prog_msg 'Error' "$@"
+}
+
+warn() {
+  prog_msg 'Warning' "$@"
+}
+
+dbg() {
+  prog_msg 'Debug' "$@"
+}
 
 # determine name of [g]sed binary
 type gsed > /dev/null 2>&1 && SED=gsed || SED=sed
@@ -80,11 +100,11 @@ type gsed > /dev/null 2>&1 && SED=gsed || SED=sed
 # warn if a non-GNU sed utility is used
 "$SED" --version < /dev/null 2> /dev/null \
 | grep GNU > /dev/null 2>&1 || \
-echo 'Warning: not using GNU `sed` (likely cause if an error occurs)'
+warn 'not using GNU `sed` (likely cause if an error occurs)'
 
 # verify the availability of pcregrep
 type pcregrep > /dev/null 2>&1 || {
-  printf '\nError: missing utility `pcregrep`\n'
+  err 'missing utility `pcregrep`'
   exit 1
 }
 
@@ -97,14 +117,12 @@ fold_it_1() {
   # ensure input file doesn't contain the fold-sequence already
   pcregrep -q -M  "\\\\\n" "$infile"
   if [[ $? -eq 0 ]]; then
-    if [[ "$quiet" -eq 0 ]]; then
-      echo
-      echo "Error: infile has a line ending with a '\\' character."
-      echo "This file cannot be folded using the '\\' strategy"
-      echo "without there being false positives produced in the"
-      echo "unfolding (i.e., this script does not force-fold"
-      echo "such lines, as described in BCP XXX, RFC XXXX)."
-      echo
+    if [[ $quiet -eq 0 ]]; then
+      err "infile has a line ending with a '\\' character."\
+          "This file cannot be folded using the '\\' strategy"\
+          "without there being false positives produced in the"\
+          "unfolding (i.e., this script does not force-fold"\
+          "such lines, as described in BCP XXX, RFC XXXX)."
     fi
     return 1
   fi
@@ -116,11 +134,9 @@ fold_it_1() {
   grep -q "^.\{$foldcol\} " "$infile"
   if [[ $? -eq 0 ]]; then
     if [[ "$quiet" -eq 0 ]]; then
-      echo
-      echo "Error: infile has a space character occurring on the"
-      echo "folding column. This file cannot be folded using the"
-      echo "'\\' strategy."
-      echo
+      err "infile has a space character occurring on the"\
+          "folding column. This file cannot be folded using the"\
+          "'\\' strategy."
     fi
     return 1
   fi
@@ -151,15 +167,13 @@ fold_it_2() {
   pcregrep -q -M  "\\\\\n[\ ]*\\\\" "$infile"
   if [[ $? -eq 0 ]]; then
     if [[ "$quiet" -eq 0 ]]; then
-      echo
-      echo "Error: infile has a line ending with a '\\' character"
-      echo "followed by a '\\' character as the first non-space"
-      echo "character on the next line.  This script cannot fold"
-      echo "this file using '\\\\' strategy without there being"
-      echo "false positives produced in the unfolding (i.e., this"
-      echo "script does not force-fold such lines, as described"
-      echo "in BCP XXX, RFC XXXX)."
-      echo
+      err "infile has a line ending with a '\\' character"\
+          "followed by a '\\' character as the first non-space"\
+          "character on the next line.  This script cannot fold"\
+          "this file using '\\\\' strategy without there being"\
+          "false positives produced in the unfolding (i.e., this"\
+          "script does not force-fold such lines, as described"\
+          "in BCP XXX, RFC XXXX)."
     fi
     return 1
   fi
@@ -187,10 +201,7 @@ fold_it() {
   grep -q $'\t' "$infile"
   if [[ $? -eq 0 ]]; then
     if [[ "$quiet" -eq 0 ]]; then
-      echo
-      echo "Error: infile contains a TAB character, which is"
-      echo "not allowed."
-      echo
+      err "infile contains a TAB character, which is not allowed."
     fi
     return 1
   fi
@@ -200,7 +211,7 @@ fold_it() {
   grep -q ".\{$testcol\}" "$infile"
   if [[ $? -ne 0 ]]; then
     if [[ "$debug" -eq 1 ]]; then
-      echo "nothing to do"
+      dbg "nothing to do"
     fi
     cp "$infile" "$outfile"
     return -1
@@ -221,7 +232,7 @@ fold_it() {
   quiet="$quiet_sav"
   if [[ "$result" -ne 0 ]]; then
     if [[ "$debug" -eq 1 ]]; then
-      echo "Folding strategy 1 didn't succeed, trying strategy 2..."
+      dbg "Folding strategy 1 didn't succeed, trying strategy 2..."
     fi
     fold_it_2
     return $?
@@ -262,7 +273,7 @@ unfold_it() {
   if [[ $? -eq 0 ]]; then
     if [[ -n "$line2" ]]; then
       if [[ "$quiet" -eq 0 ]]; then
-        echo "Error: the second line is not empty."
+        err "the second line is not empty."
       fi
       return 1
     fi
@@ -273,7 +284,7 @@ unfold_it() {
   if [[ $? -eq 0 ]]; then
     if [[ -n "$line2" ]]; then
       if [[ "$quiet" -eq 0 ]]; then
-        echo "Error: the second line is not empty."
+        err "the second line is not empty."
       fi
       return 1
     fi
@@ -281,7 +292,7 @@ unfold_it() {
     return $?
   fi
   if [[ "$debug" -eq 1 ]]; then
-    echo "nothing to do"
+    dbg "nothing to do"
   fi
   cp "$infile" "$outfile"
   return -1
@@ -323,27 +334,21 @@ process_input() {
 
   if [[ -z "$infile" ]]; then
     if [[ "$quiet" -eq 0 ]]; then
-      echo
-      echo "Error: infile parameter missing (use -h for help)"
-      echo
+      err "infile parameter missing (use -h for help)"
     fi
     exit 1
   fi
 
   if [[ -z "$outfile" ]]; then
     if [[ "$quiet" -eq 0 ]]; then
-      echo
-      echo "Error: outfile parameter missing (use -h for help)"
-      echo
+      err "outfile parameter missing (use -h for help)"
       exit 1
     fi
   fi
 
   if [[ ! -f "$infile" ]]; then
     if [[ "$quiet" -eq 0 ]]; then
-      echo
-      echo "Error: specified file \"$infile\" is does not exist."
-      echo
+      err "specified file \"$infile\" is does not exist."
       exit 1
     fi
   fi
@@ -355,8 +360,7 @@ process_input() {
   fi
   if [[ "$maxcol" -lt "$min_supported" ]]; then
     if [[ "$quiet" -eq 0 ]]; then
-      printf "\nError: the folding column cannot be less than"
-      printf " $min_supported.\n\n"
+      err "the folding column cannot be less than $min_supported."
     fi
     exit 1
   fi
@@ -366,8 +370,7 @@ process_input() {
        + ${#equal_chars})
   if [[ "$maxcol" -gt "$max_supported" ]]; then
     if [[ "$quiet" -eq 0 ]]; then
-      printf "\nError: the folding column cannot be more than"
-      printf " $max_supported.\n\n"
+      err "the folding column cannot be more than $max_supported."
     fi
     exit 1
   fi

--- a/rfcfold
+++ b/rfcfold
@@ -110,7 +110,7 @@ fold_it_1() {
   fi
 
   # where to fold
-  foldcol=`expr "$maxcol" - 1` # for the inserted '\' char
+  foldcol=$(expr "$maxcol" - 1) # for the inserted '\' char
 
   # ensure input file doesn't contain whitespace on the fold column
   grep -q "^.\{$foldcol\} " "$infile"
@@ -126,11 +126,11 @@ fold_it_1() {
   fi
 
   # center header text
-  length=`expr ${#hdr_txt_1} + 2`
-  left_sp=`expr \( "$maxcol" - "$length" \) / 2`
-  right_sp=`expr "$maxcol" - "$length" - "$left_sp"`
-  header=`printf "%.*s %s %.*s" "$left_sp" "$equal_chars"\
-                   "$hdr_txt_1" "$right_sp" "$equal_chars"`
+  length=$(expr ${#hdr_txt_1} + 2)
+  left_sp=$(expr \( "$maxcol" - "$length" \) / 2)
+  right_sp=$(expr "$maxcol" - "$length" - "$left_sp")
+  header=$(printf "%.*s %s %.*s" "$left_sp" "$equal_chars"\
+                   "$hdr_txt_1" "$right_sp" "$equal_chars")
 
   # generate outfile
   echo "$header" > "$outfile"
@@ -145,7 +145,7 @@ fold_it_1() {
 
 fold_it_2() {
   # where to fold
-  foldcol=`expr "$maxcol" - 1` # for the inserted '\' char
+  foldcol=$(expr "$maxcol" - 1) # for the inserted '\' char
 
   # ensure input file doesn't contain the fold-sequence already
   pcregrep -q -M  "\\\\\n[\ ]*\\\\" "$infile"
@@ -165,11 +165,11 @@ fold_it_2() {
   fi
 
   # center header text
-  length=`expr ${#hdr_txt_2} + 2`
-  left_sp=`expr \( "$maxcol" - "$length" \) / 2`
-  right_sp=`expr "$maxcol" - "$length" - "$left_sp"`
-  header=`printf "%.*s %s %.*s" "$left_sp" "$equal_chars"\
-                   "$hdr_txt_2" "$right_sp" "$equal_chars"`
+  length=$(expr ${#hdr_txt_2} + 2)
+  left_sp=$(expr \( "$maxcol" - "$length" \) / 2)
+  right_sp=$(expr "$maxcol" - "$length" - "$left_sp")
+  header=$(printf "%.*s %s %.*s" "$left_sp" "$equal_chars"\
+                   "$hdr_txt_2" "$right_sp" "$equal_chars")
 
   # generate outfile
   echo "$header" > "$outfile"
@@ -196,7 +196,7 @@ fold_it() {
   fi
 
   # check if file needs folding
-  testcol=`expr "$maxcol" + 1`
+  testcol=$(expr "$maxcol" + 1)
   grep -q ".\{$testcol\}" "$infile"
   if [ $? -ne 0 ]; then
     if [[ $debug -eq 1 ]]; then
@@ -230,7 +230,7 @@ fold_it() {
 }
 
 unfold_it_1() {
-  temp_dir=`mktemp -d`
+  temp_dir=$(mktemp -d)
 
   # output all but the first two lines (the header) to wip file
   awk "NR>2" "$infile" > "$temp_dir/wip"
@@ -242,7 +242,7 @@ unfold_it_1() {
 }
 
 unfold_it_2() {
-  temp_dir=`mktemp -d`
+  temp_dir=$(mktemp -d)
 
   # output all but the first two lines (the header) to wip file
   awk "NR>2" "$infile" > "$temp_dir/wip"
@@ -255,9 +255,9 @@ unfold_it_2() {
 
 unfold_it() {
   # check if file needs unfolding
-  line=`head -n 1 "$infile"`
-  line2=`$SED -n '2p' "$infile"`
-  result=`echo "$line" | fgrep "$hdr_txt_1"`
+  line=$(head -n 1 "$infile")
+  line2=$($SED -n '2p' "$infile")
+  result=$(echo "$line" | fgrep "$hdr_txt_1")
   if [ $? -eq 0 ]; then
     if [ -n "$line2" ]; then
       if [[ $quiet -eq 0 ]]; then
@@ -268,7 +268,7 @@ unfold_it() {
     unfold_it_1
     return $?
   fi
-  result=`echo $line | fgrep "$hdr_txt_2"`
+  result=$(echo $line | fgrep "$hdr_txt_2")
   if [ $? -eq 0 ]; then
     if [ -n "$line2" ]; then
       if [[ $quiet -eq 0 ]]; then
@@ -348,9 +348,9 @@ process_input() {
   fi
 
   if [[ $strategy -eq 2 ]]; then
-    min_supported=`expr ${#hdr_txt_2} + 9`
+    min_supported=$(expr ${#hdr_txt_2} + 9)
   else
-    min_supported=`expr ${#hdr_txt_1} + 9`
+    min_supported=$(expr ${#hdr_txt_1} + 9)
   fi
   if [[ $maxcol -lt $min_supported ]]; then
     if [[ $quiet -eq 0 ]]; then
@@ -361,8 +361,8 @@ process_input() {
   fi
 
   # this is only because the code otherwise runs out of equal_chars
-  max_supported=`expr ${#equal_chars} + 1 + ${#hdr_txt_1} + 1\
-       + ${#equal_chars}`
+  max_supported=$(expr ${#equal_chars} + 1 + ${#hdr_txt_1} + 1\
+       + ${#equal_chars})
   if [[ $maxcol -gt $max_supported ]]; then
     if [[ $quiet -eq 0 ]]; then
       printf "\nError: the folding column cannot be more than"

--- a/rfcfold
+++ b/rfcfold
@@ -79,11 +79,11 @@ type gsed > /dev/null 2>&1 && SED=gsed || SED=sed
 
 # warn if a non-GNU sed utility is used
 "$SED" --version < /dev/null 2> /dev/null \
-| grep GNU >/dev/null 2>&1 || \
+| grep GNU > /dev/null 2>&1 || \
 echo 'Warning: not using GNU `sed` (likely cause if an error occurs)'
 
 # verify the availability of pcregrep
-type pcregrep >> /dev/null 2>&1 || {
+type pcregrep > /dev/null 2>&1 || {
   printf '\nError: missing utility `pcregrep`\n'
   exit 1
 }
@@ -136,7 +136,7 @@ fold_it_1() {
   echo "$header" > "$outfile"
   echo "" >> "$outfile"
   "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\n\2/;t M;b;:M;P;D;'\
-    < "$infile" >> "$outfile" 2>/dev/null
+    < "$infile" >> "$outfile" 2> /dev/null
   if [[ $? -ne 0 ]]; then
     return 1
   fi
@@ -175,7 +175,7 @@ fold_it_2() {
   echo "$header" > "$outfile"
   echo "" >> "$outfile"
   "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\n\\\2/;t M;b;:M;P;D;'\
-    < "$infile" >> "$outfile" 2>/dev/null
+    < "$infile" >> "$outfile" 2> /dev/null
   if [[ $? -ne 0 ]]; then
     return 1
   fi


### PR DESCRIPTION
* improve style consistency
* do not append to /dev/null
* use more robust shell constructs
* defensive variable quoting
* send diagnostic messages to STDERR
* warn about unknown options
* kept line length below 70 characters to avoid the need for folding in the I-D