### PR TITLE
rfcfold: use GNU Awk for checks if available

### DIFF
--- a/rfcfold
+++ b/rfcfold
@@ -197,10 +197,14 @@ fold_it() {
 
   # folding of input containing ASCII control or non-ASCII characters
   # may result in a wrong folding column and is not supported
-  env LC_ALL=C awk '/[\000-\014\016-\037\177]/{exit 1}' "$infile" ||\
-    warn 'infile contains ASCII control characters (unsupported)'
-  env LC_ALL=C awk '/[^\000-\177]/{exit 1}' "$infile" ||\
-    warn 'infile contains non-ASCII characters (unsupported)'
+  if type gawk > /dev/null 2>&1; then
+    env LC_ALL=C gawk '/[\000-\014\016-\037\177]/{exit 1}' "$infile"\
+    || warn 'infile contains ASCII control characters (unsupported)'
+    env LC_ALL=C gawk '/[^\000-\177]/{exit 1}' "$infile"\
+    || warn 'infile contains non-ASCII characters (unsupported)'
+  else
+    dbg 'no GNU Awk, skipping checks for special characters'
+  fi
 
   # check if file needs folding
   testcol=$(expr "$maxcol" + 1)


### PR DESCRIPTION
If GNU Awk is available, use it to check if the input file contains
ASCII control or non-ASCII characters.